### PR TITLE
Prepend brushlib directory rather than appending

### DIFF
--- a/tests/SConscript
+++ b/tests/SConscript
@@ -19,7 +19,7 @@ if sys.platform == 'win32':
     testlib_env.Append(LIBS=['intl'])
 elif sys.platform == "msys" and os.environ.get("MSYSTEM") != "MSYS":
     testlib_env.Append(LIBS=['intl'])
-testlib_env.Append(CPPPATH=['../'], LIBPATH=['../'])
+testlib_env.Prepend(CPPPATH=['../'], LIBPATH=['../'])
 
 if testlib_env['enable_gperftools']:
     parse_pkg_config(testlib_env, "libprofiler")


### PR DESCRIPTION
This ensures we get brushlib from the source directory, not a different one that might already be installed.

Before this change, MyPaint 1.2.0 builds like this:

```
/usr/bin/clang -arch x86_64 -arch i386 -o brushlib/tests/test-brush-persistence -O3 brushlib/tests/test-brush-persistence.o -L/opt/local/lib -Lbrushlib -lmypaint-tests -lmypaint -lm -lintl -ljson-c
/usr/bin/clang -arch x86_64 -arch i386 -o brushlib/tests/test-details -O3 brushlib/tests/test-details.o -L/opt/local/lib -Lbrushlib -lmypaint-tests -lmypaint -lm -lintl -ljson-c
```

`-L/opt/local/lib -Lbrushlib` means it will check for libmypaint-tests.a and libmypaint.a in /opt/local/lib first, and only if not found there will it look for them in brushlib. This can cause the build to fail if /opt/local/lib/libmypaint.a already exists, for example from another MyPaint installation. In my case, my already-installed MyPaint was built for x86_64 only, and I was now trying to build MyPaint universal (for x86_64 and i386); the build failed because i386 symbols were not found in the already-installed x86_64 version of the library. But it could fail for other reasons as well.
